### PR TITLE
corrected img_dimensions syntax in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ Install Flow2ML python files via pip.
 ## Sample Code
 ```py
     # To be given input by the user.
-    img_dimensions = (150,150)
+    img_dimensions = (150,150,3)
     test_val_split = 0.1
 
     # Import flow2ml package


### PR DESCRIPTION
# Description:

Fixed the `img_dimensions` line in the README after debugging Filters.py. 

Reason: 
- Previously, the number of channels was not mentioned, and only the size was present in the form of (height, width)
- Using this code raised a lot of errors when using normal RGB images, since the dimensions did not include the number of channels
- These corrected dimensions now include the width, height as well as number of channels, which is set to 3 for normal RGBB images
- It would work as a good starting point for users trying the sample code with some images. 

## Type of change:

- [X] Bug fix (non-breaking change which fixes an issue)

 
# Checklist:
- [X] My code follows the style guidelines of this project.
- [X] I have performed a self-review of my own code.
- [X] I have commented my code, particularly in hard-to-understand areas.
- [X] I have made corresponding changes to the documentation.
- [X] My changes generate no new warnings.
- [X] I have added tests that prove my fix is effective or that my feature works.
- [X] New and existing unit tests pass locally with my changes.
- [X] Any dependent changes have been merged and published in downstream modules.

# Screenshots / Video:

![image](https://user-images.githubusercontent.com/50259869/113112921-5d33fc80-9227-11eb-8515-07e42592c909.png)
