### PR TITLE
Fix color reversal

### DIFF
--- a/flow2ml/Filters.py
+++ b/flow2ml/Filters.py
@@ -38,7 +38,7 @@ class Filters:
         median = cv2.medianBlur(img, 5)
         
         # saving the image by
-        plt.imsave(classPath+"/MedianImages/Median"+image, median)
+        plt.imsave(classPath+"/MedianImages/Median"+image, cv2.cvtColor(median, cv2.COLOR_RGB2BGR))
   
   def applylaplacian(self,classPath):
     ''' 
@@ -130,7 +130,7 @@ class Filters:
         gaussian = cv2.GaussianBlur(img,(5,5),0)
         
         # saving the image.
-        plt.imsave(classPath+"/GaussianImages/gaussian"+image, gaussian)
+        plt.imsave(classPath+"/GaussianImages/gaussian"+image, cv2.cvtColor(gaussian, cv2.COLOR_RGB2BGR))
 
   def visualizeFilters(self):
     ''' filtered_image


### PR DESCRIPTION
# Description:

Fixes color reversal issue occurring for Gaussian and Median filters due to using Matplotlib to save the image. It occurred since CV2 and Matplotlib, when used together, change the order of RGB channels. Uses `COLOR_RGB2BGR` functionality to fix the issue.

Fixes #28

## Type of change:

- [x] Bug fix (non-breaking change which fixes an issue)

# Checklist:

- [X] My code follows the style guidelines of this project.
- [X] I have performed a self-review of my own code.
- [x] My changes generate no new warnings.

# Screenshots:

(Original image on the left, Gaussian blur in middle, Median blur on the right)

Before the fix:

![image](https://user-images.githubusercontent.com/50259869/113183379-93966980-9271-11eb-926a-4ed0ee6dfb30.png)

After the fix:

![image](https://user-images.githubusercontent.com/50259869/113183597-d48e7e00-9271-11eb-81cc-97536780d90b.png)
