### PR TITLE
Add scaling operation

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,7 +93,7 @@ Install Flow2ML python files via pip.
     flow.applyFilters( filters )
 
     # Define The augmentation operations to be used
-    operations = {'flip': 'horizontal', 'rotate': 90, 'shear': {'x_axis': 5, 'y_axis': 15, 'crop': [50, 100, 50, 100]}}
+    operations = {'flip': 'horizontal', 'rotate': 90, 'shear': {'x_axis': 5, 'y_axis': 15}, 'crop': [50, 100, 50, 100], 'scale': 0.1}
 
     # Apply The Augmentation
     flow.applyAugmentation( operations )

--- a/flow2ml/Data_Augumentation.py
+++ b/flow2ml/Data_Augumentation.py
@@ -147,3 +147,35 @@ class Data_Augumentation:
             raise Exception("Cropping needs random parameter or list of coordinates.")
         except Exception as e:
           print(f"Crop operation failed due to {e}")
+  
+  def applyScale(self,classPath):
+    ''' 
+      Applies scaling augmentation to all the images in the given folder. Scales the image by the given ratio.
+      Args : 
+        classPath : (string) directory containing images for a particular class.
+    '''
+    ratio = self.operations['scale']
+    try:
+      os.mkdir(classPath+"/ScaledImages")    
+    except:
+      raise Exception("Unable to create directory for scaled images.")
+    for image in list(os.listdir(classPath)):
+      
+      # Read image
+      img = cv2.imread(classPath+"/"+image)
+
+      if isinstance(self.operations['scale'], str):
+        raise Exception("Scaling ratio cannot be a string.")
+      else:
+        if img is not None:
+          try:
+            if ratio < 0:
+              raise Exception("Scale ratio cannot be negative.")
+            else:
+              # applies scale augmentation to the image.
+              Scaled = cv2.resize(img, (round(img.shape[0] * ratio), round(img.shape[1] * ratio)))
+              # # saving the image by
+              plt.imsave(classPath+"/ScaledImages/Scaled"+image, cv2.cvtColor(Scaled, cv2.COLOR_RGB2BGR))
+          except Exception as e:
+            print(f"Scale operation failed due to {e}")
+  

--- a/flow2ml/Flow.py
+++ b/flow2ml/Flow.py
@@ -122,7 +122,10 @@ class Flow(Data_Loader,Filters,Data_Augumentation):
         
         if operation == "crop":
           self.applyCrop(path)
-      
+
+        if operation == "scale":
+          self.applyScale(path)
+
         time.sleep(0.1)
         self.update_progress( progress[progress_i]/100.0, f"Augmented all images in {folder}" )
         progress_i += 1

--- a/flow2ml/README.md
+++ b/flow2ml/README.md
@@ -51,6 +51,7 @@ Applies the following augmentation operations to the images in data directory<br
     <li>rotation</li>
     <li>shearing</li>
     <li>cropping</li>
+    <li>scaling</li>
 </ol>
 <br><hr><br>
 Flow.py contains Flow class which connects various other classes and maintains the work flow.


### PR DESCRIPTION
# Description:

Added a method in Data_Augumentation.py file for scaling the image based on the scaling ratio given by the user. The images are added to class/ScaledImages.

It is used in the following way:
```
flow = Flow( 'dataset_dir' , 'data_dir' )
operations = {'scale': 1.5}

flow.applyAugmentation( operations )
```

Fixes #61 

## Type of change:

- [x] New feature (non-breaking change which adds functionality)
 
# Checklist:

- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] My changes generate no new warnings.

# Screenshots / Video:

Original, scale:2, scale:0.5
<p float="left">
  <img src="https://user-images.githubusercontent.com/50259869/118665838-47e35380-b810-11eb-9c02-e273f93a93d7.png">
  <img src="https://user-images.githubusercontent.com/50259869/118665864-4f0a6180-b810-11eb-9c72-3e20558398b0.png">
  <img src="https://user-images.githubusercontent.com/50259869/118665928-60ec0480-b810-11eb-838d-a6e48c8529e9.png">
</p>