### PR TITLE
Add zoom augmentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,7 +93,7 @@ Install Flow2ML python files via pip.
     flow.applyFilters( filters )
 
     # Define The augmentation operations to be used
-    operations = {'flip': 'horizontal', 'rotate': 90, 'shear': {'x_axis': 5, 'y_axis': 15}, 'crop': [50, 100, 50, 100], 'scale': 0.1}
+    operations = {'flip': 'horizontal', 'rotate': 90, 'shear': {'x_axis': 5, 'y_axis': 15}, 'crop': [50, 100, 50, 100], 'scale': 0.1, 'zoom': 2}
 
     # Apply The Augmentation
     flow.applyAugmentation( operations )

--- a/flow2ml/Data_Augumentation.py
+++ b/flow2ml/Data_Augumentation.py
@@ -199,7 +199,7 @@ class Data_Augumentation:
         raise Exception("Zoom factor cannot be a string.")
       else:
         
-        factor = round(self.operations['zoom'])
+        factor = self.operations['zoom']
         if factor < 1:
           raise Exception("Zoom factor cannot be lesser than 1.")
         else:

--- a/flow2ml/Data_Augumentation.py
+++ b/flow2ml/Data_Augumentation.py
@@ -178,4 +178,43 @@ class Data_Augumentation:
               plt.imsave(classPath+"/ScaledImages/Scaled"+image, cv2.cvtColor(Scaled, cv2.COLOR_RGB2BGR))
           except Exception as e:
             print(f"Scale operation failed due to {e}")
-  
+
+  def applyZoom(self,classPath):
+    ''' 
+      Applies zooming augmentation to all the images in the given folder. It zooms the images by the given ratio
+      Args : 
+        classPath : (string) directory containing images for a particular class.
+    '''
+    try:
+      os.mkdir(classPath+"/ZoomedImages")    
+    except:
+      raise Exception("Unable to create directory for zoomed images.")
+
+    for image in list(os.listdir(classPath)):
+      
+      # Read image
+      img = cv2.imread(classPath+"/"+image)
+      
+      if isinstance(self.operations['zoom'], str):
+        raise Exception("Zoom factor cannot be a string.")
+      else:
+        
+        factor = round(self.operations['zoom'])
+        if factor < 1:
+          raise Exception("Zoom factor cannot be lesser than 1.")
+        else:
+          if img is not None:
+            try:
+              # applies zooming augmentation to the image.
+              h, w = img.shape[0], img.shape[1]
+              Zoomed = cv2.resize(img, (round(img.shape[1] * factor), round(img.shape[0] * factor)))
+              w_zoomed, h_zoomed = Zoomed.shape[1], Zoomed.shape[0]
+              x1 = round((float(w_zoomed) / 2) - (float(w) / 2))
+              x2 = round((float(w_zoomed) / 2) + (float(w) / 2))
+              y1 = round((float(h_zoomed) / 2) - (float(h) / 2))
+              y2 = round((float(h_zoomed) / 2) + (float(h) / 2))
+              Zoomed = Zoomed[y1:y2, x1:x2]         
+              # saving the image by
+              plt.imsave(classPath+"/ZoomedImages/Zoomed"+image, cv2.cvtColor(Zoomed, cv2.COLOR_RGB2BGR))
+            except Exception as e:
+              print(f"Zooming operation failed due to {e}")

--- a/flow2ml/Flow.py
+++ b/flow2ml/Flow.py
@@ -126,6 +126,9 @@ class Flow(Data_Loader,Filters,Data_Augumentation):
         if operation == "scale":
           self.applyScale(path)
 
+        if operation == "zoom":
+          self.applyZoom(path)
+
         time.sleep(0.1)
         self.update_progress( progress[progress_i]/100.0, f"Augmented all images in {folder}" )
         progress_i += 1

--- a/flow2ml/README.md
+++ b/flow2ml/README.md
@@ -52,6 +52,7 @@ Applies the following augmentation operations to the images in data directory<br
     <li>shearing</li>
     <li>cropping</li>
     <li>scaling</li>
+    <li>zooming</li>
 </ol>
 <br><hr><br>
 Flow.py contains Flow class which connects various other classes and maintains the work flow.


### PR DESCRIPTION
# Description:

Added a method in Data_Augumentation.py file for zooming the image based on the ratio given by the user.

It is used in the following way:
```
flow = Flow( 'dataset_dir' , 'data_dir' )
operations = {'zoom': 2}

flow.applyAugmentation( operations )
```

Fixes #60 

## Type of change:

- [x] New feature (non-breaking change which adds functionality)
 
# Checklist:

- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] My changes generate no new warnings.

# Screenshots / Video:

Original, zoom:1.3, zoom:2
<p float="left">
  <img src="https://user-images.githubusercontent.com/50259869/118857206-68d1a480-b8f5-11eb-9445-45a22d2e1077.jpg" width="100" />
  <img src="https://user-images.githubusercontent.com/50259869/118858277-98cd7780-b8f6-11eb-9ade-8e78a4d561c8.jpg" width="100" />
  <img src="https://user-images.githubusercontent.com/50259869/118857424-a9312280-b8f5-11eb-85cb-26bc1bbd63fa.jpg" width="100" />
</p>