### PR TITLE
Allow dataloader to split data without preprocessing

### DIFF
--- a/flow2ml/Data_Loader.py
+++ b/flow2ml/Data_Loader.py
@@ -40,6 +40,28 @@ class Data_Loader:
     self.classes = training_classes
     return training_classes
 
+  def process_images(self,img_source,img_dest,img_name,classPath):
+    '''
+      Copies the given image to the processedData folder and assigns the relevant label
+      Args :
+        img_source : (string) path to the image to be copied
+        img_dest : (string) path to where the image should be copied
+        img_name : (string) original image name
+        classPath : (string) directory containing images for a particular class.
+      Return :
+        None
+    '''
+    shutil.copy(img_source,img_dest)
+              
+    # Handle path seperators for Linux and Windows
+    if '/' in classPath:
+      folderName = list(classPath.split("/"))[2]
+    else:
+      folderName = os.path.split(classPath)[1]  
+                
+    # Assign relevant labels to the image
+    ind = self.classes.index(folderName)
+    self.img_label[img_name] = np.squeeze(np.eye(len(self.classes))[ind])
 
   def create_dataset(self,classPath):
     '''
@@ -64,41 +86,23 @@ class Data_Loader:
     for image in list(os.listdir(classPath)):
       
         if (image.find("Images") != -1):
-          # path is a folder
+          # path is a folder containing multiple preprocessed images
 
             for image_in_folder in (list(os.listdir(os.path.join(classPath,image)))):
               
 
               filtered_image = os.path.join(classPath,image,image_in_folder)
-              shutil.copy(filtered_image,final_data_folder)
-              
-              # Handle path seperators for Linux and Windows
-              if '/' in classPath:
-                folderName = list(classPath.split("/"))[2]
-              else:
-                folderName = os.path.split(classPath)[1]              
-
-              ind = self.classes.index(folderName)
-              self.img_label[image_in_folder] = np.squeeze(np.eye(len(self.classes))[ind])
+              self.process_images(filtered_image, final_data_folder, image_in_folder, classPath)
     
     if not any([i != -1 for i in [image.find("Images") for image in os.listdir(classPath)]]):
 
       for image in list(os.listdir(classPath)):
 
         if not(image.find("Images") != -1):
-        # path is image
+        # path is an image since folder could not be found
         
           original_image = os.path.join(classPath,image)
-          shutil.copy(original_image, final_data_folder)
-
-          # Handle path seperators for Linux and Windows
-          if '/' in classPath:
-            folderName = list(classPath.split("/"))[2]
-          else:
-            folderName = os.path.split(classPath)[1]              
-
-          ind = self.classes.index(folderName)
-          self.img_label[image] = np.squeeze(np.eye(len(self.classes))[ind])
+          self.process_images(original_image, final_data_folder, image, classPath)
 
     return self.img_label
 

--- a/flow2ml/Data_Loader.py
+++ b/flow2ml/Data_Loader.py
@@ -94,6 +94,7 @@ class Data_Loader:
               filtered_image = os.path.join(classPath,image,image_in_folder)
               self.process_images(filtered_image, final_data_folder, image_in_folder, classPath)
     
+    # If no folders of preprocessed images are found, move original images to processedData
     if not any([i != -1 for i in [image.find("Images") for image in os.listdir(classPath)]]):
 
       for image in list(os.listdir(classPath)):

--- a/flow2ml/Data_Loader.py
+++ b/flow2ml/Data_Loader.py
@@ -80,6 +80,25 @@ class Data_Loader:
 
               ind = self.classes.index(folderName)
               self.img_label[image_in_folder] = np.squeeze(np.eye(len(self.classes))[ind])
+    
+    if not any([i != -1 for i in [image.find("Images") for image in os.listdir(classPath)]]):
+
+      for image in list(os.listdir(classPath)):
+
+        if not(image.find("Images") != -1):
+        # path is image
+        
+          original_image = os.path.join(classPath,image)
+          shutil.copy(original_image, final_data_folder)
+
+          # Handle path seperators for Linux and Windows
+          if '/' in classPath:
+            folderName = list(classPath.split("/"))[2]
+          else:
+            folderName = os.path.split(classPath)[1]              
+
+          ind = self.classes.index(folderName)
+          self.img_label[image] = np.squeeze(np.eye(len(self.classes))[ind])
 
     return self.img_label
 
@@ -119,7 +138,6 @@ class Data_Loader:
     '''
 
     self.img_label = img_label_dict
-    
     # differentiating the complete dataset into training and validating datasets.
     img_name_train, img_name_val, output_label_train, output_label_val = train_test_split(
                                                                     list(self.img_label.keys()),


### PR DESCRIPTION
# Description:

Originally, dataloader did not split the data into train and test unless augmentation / filters were applied which led to 0 images in the processedData folder. This fix copies original images to the processedData folder if any preprocessed images are not available, thus allowing us to split into train and test sets.

Fixes #106 

## Type of change:

- [x] Bug fix (non-breaking change which fixes an issue)

 
# Checklist:

- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] My changes generate no new warnings.

# Screenshots / Video:

Have verified that old functionality with augmentations and filters works. Have also verified that running just the following 2 lines also works without any preprocessing and the original images get copied to processedData instead:

```
flow = Flow( 'dataset_dir' , 'data_dir' )

(train_x, train_y, val_x, val_y) = flow.getDataset( img_dimensions, test_val_split )
```